### PR TITLE
Update admin controls active option background color

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -925,6 +925,7 @@ body {
 // admin
 
 .admin-controls .nav-pills > li a.active {
+  background: var(--primary-medium, $primary-medium);
   color: var(--secondary, $secondary);
 }
 


### PR DESCRIPTION
Hi, 
The background color and text color of selected option is same in invited panel of discourse

![image](https://user-images.githubusercontent.com/37538929/116001616-b61c6800-a60e-11eb-9881-ef5a63efc420.png)