### PR TITLE
UX: Topic list refactor

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -968,16 +968,16 @@ body {
 // topic list
 
 body:not(.categories-list) .topic-list {
-  tbody {
+  .topic-list-body {
     border: none;
   }
 
-  tr {
+  .topic-list-item {
     border: none;
   }
 
   .topic-list-item-separator {
-    td {
+    .topic-list-data {
       display: block;
       width: 486px;
       margin-bottom: 1em;

--- a/javascripts/discourse/templates/list/custom-topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/custom-topic-list-item.hbr
@@ -6,7 +6,7 @@
 </td>
 {{/if}}
 
-<div class='main-link clearfix' colspan="1">
+<div class='main-link topic-list-data clearfix' colspan="1">
   <span class='link-top-line'>
     <div class="byline">
       <div class="author">


### PR DESCRIPTION
This PR adjusts the css to target classes instead of elements. It also adds a class to an element which should contain the new class of `topic-list-data`.