### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -1,5 +1,5 @@
 <script type="text/discourse-plugin" version="0.8">
-  import { htmlSafe } from "@ember/template";
+  const { htmlSafe } = require("@ember/template");
   const { findRawTemplate } = require("discourse-common/lib/raw-templates");
 
   api.modifyClass('component:topic-list-item', {

--- a/common/header.html
+++ b/common/header.html
@@ -1,11 +1,12 @@
 <script type="text/discourse-plugin" version="0.8">
+  import { htmlSafe } from "@ember/template";
   const { findRawTemplate } = require("discourse-common/lib/raw-templates");
 
   api.modifyClass('component:topic-list-item', {
     renderTopicListItem() {
       const template = findRawTemplate("list/custom-topic-list-item");
       if (template) {
-        this.set("topicListItemContents", template(this).htmlSafe());
+        this.set("topicListItemContents", htmlSafe(template(this)));
       }
     },
   });


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions