### PR TITLE
UX: Make welcome topic banner use Fakebook card style

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1169,3 +1169,16 @@ section.tag-info {
 .embedded-posts.top .row .topic-body {
   border: none;
 }
+
+// Welcome Topic Banner
+.welcome-topic-banner {
+  @include fb-background();
+  border: 1px solid $border-color;
+  border-radius: 4px;
+  margin-bottom: 12px;
+  box-shadow: none;
+
+  .col-text {
+    margin-left: 1.25em;
+  }
+}


### PR DESCRIPTION
This PR adds the Facebook card styling to the new welcome topic banner like so:

**Before:**
<img width="854" alt="Screen Shot 2022-08-11 at 3 59 01 PM" src="https://user-images.githubusercontent.com/30090424/184256455-3e59d5dd-a5d6-4fcf-8cac-4874c34ff2b0.png">

**After:**
<img width="861" alt="Screen Shot 2022-08-11 at 3 59 11 PM" src="https://user-images.githubusercontent.com/30090424/184256466-f5309a34-2b08-4667-b445-a8ccee0e5971.png">

