### PR TITLE
DEV: Remove topic list header override

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,6 +1,10 @@
 @import "common/foundation/variables";
 @import "variables";
 
+.topic-list-header {
+  display: none;
+}
+
 .alert.alert-info {
   margin-bottom: 10px;
 }

--- a/javascripts/discourse/templates/topic-list-header.hbr
+++ b/javascripts/discourse/templates/topic-list-header.hbr
@@ -1,1 +1,0 @@
-{{!-- Remove topic list header --}}


### PR DESCRIPTION
After investigating if we can remove some template overrides in this theme component, the result is this PR where we can remove the `topic-list-header.hbr` override and replace it with a simple CSS `display: none;`