### PR TITLE
DEV: Add sidebar support

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -1,5 +1,6 @@
 @import "common/foundation/variables";
 @import "variables";
+@import "sidebar";
 
 .topic-list-header {
   display: none;

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -9,6 +9,11 @@ body:not(.categories-list) .topic-list {
   table-layout: auto !important;
   display: block;
   overflow: hidden;
+
+  .topic-list-data {
+    max-width: unset;
+  }
+
   tbody {
     display: block;
     tr {

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,0 +1,33 @@
+.sidebar-wrapper {
+  background: none;
+
+  .sidebar-scroll-wrap {
+    --scrollbarThumbBg: var(--primary-300);
+    --scrollbarWidth: 0.5em;
+
+    &:hover {
+      &::-webkit-scrollbar-thumb {
+        border: none;
+      }
+    }
+  }
+}
+
+.sidebar-section-header.btn {
+  border: none;
+}
+
+.sidebar-footer-wrapper {
+  background: none;
+  .desktop-view & {
+    .sidebar-footer-container {
+      &:before {
+        background: linear-gradient(
+          to bottom,
+          transparent,
+          rgba(var(--primary-low-rgb), 1)
+        );
+      }
+    }
+  }
+}

--- a/scss/sidebar.scss
+++ b/scss/sidebar.scss
@@ -1,3 +1,4 @@
+// Sidebar Style Overrides
 .sidebar-wrapper {
   background: none;
 
@@ -21,12 +22,80 @@
   background: none;
   .desktop-view & {
     .sidebar-footer-container {
+      background: none;
       &:before {
         background: linear-gradient(
           to bottom,
           transparent,
           rgba(var(--primary-low-rgb), 1)
         );
+      }
+    }
+  }
+}
+
+// Fakebook overrides when sidebar_enabled
+.has-sidebar-page {
+  @media screen and (min-width: 650px) {
+    &.navigation-topics,
+    &.categories-list,
+    &.tags-page,
+    &[class*="category-"]:not(.archetype-regular):not(.archetype-banner) {
+      // Structuring the main grid layout
+      #main-outlet {
+        @if $sidebar-alignment == "left" {
+          grid-template-areas:
+            "alerts alerts alerts"
+            "pins pins pins"
+            "nav nav sidebar"
+            "topic-list topic-list sidebar";
+        } @else {
+          // todo
+          grid-template-areas:
+            "alerts alerts alerts"
+            "pins pins pins"
+            "sidebar topic-list nav";
+        }
+        // todo max-width: 920px;
+      }
+
+      // Changing the layout to fit the grid
+      .category-breadcrumb {
+        font-size: var(--font-0);
+      }
+
+      .navigation-controls {
+        flex-wrap: nowrap;
+        width: unset;
+        align-self: center;
+      }
+
+      .list-controls {
+        .container {
+          --nav-space: 0.75em;
+          margin-bottom: var(--nav-space);
+
+          .navigation-container {
+            --nav-space: 0;
+          }
+        }
+
+        #navigation-bar {
+          margin-top: unset;
+        }
+
+        .nav-pills {
+          flex-direction: row;
+        }
+
+        .category-navigation,
+        .navigation-container {
+          flex-wrap: nowrap;
+        }
+
+        ol {
+          flex-wrap: nowrap;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR intends to update the Fakebook theme to support Discourse's new sidebar.

- [x] Make new sidebar transparent
- [x] Move navigation controls above/within new sidebar or above topic list
> Decided to put above topic list as sidebar pluginAPI is still experimental.
- [x] Grid adjustments