### PR TITLE
UX: Fix post cards not full height under avatar

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -561,6 +561,14 @@ body {
   border-radius: 4px;
 }
 
+.topic-avatar {
+  height: unset;
+}
+
+.topic-post.sticky-avatar .topic-avatar {
+  margin-bottom: 0;
+}
+
 // Suggested
 
 #suggested-topics {


### PR DESCRIPTION
This PR fixes a UI bug with posts (as mentioned [here](https://meta.discourse.org/t/fakebook-a-theme-for-social-media-lovers/109079/140?u=keegan)):

**Before:**
<img width="798" alt="Screen Shot 2022-09-01 at 7 47 48 AM" src="https://user-images.githubusercontent.com/30090424/187945278-faf5fb78-39f0-42f3-83f3-647bd1de8758.png">


**After:**
<img width="777" alt="Screen Shot 2022-09-01 at 7 51 58 AM" src="https://user-images.githubusercontent.com/30090424/187945299-f3e82a17-c497-4742-8c13-d029e3fdf675.png">
