### PR TITLE
DEV: Suppress deprecations and warnings

### DIFF
--- a/common/header.html
+++ b/common/header.html
@@ -3,6 +3,8 @@
   const { findRawTemplate } = require("discourse-common/lib/raw-templates");
 
   api.modifyClass('component:topic-list-item', {
+    pluginId: "Fakebook",
+
     renderTopicListItem() {
       const template = findRawTemplate("list/custom-topic-list-item");
       if (template) {

--- a/javascripts/discourse/templates/list/custom-topic-list-item.hbr
+++ b/javascripts/discourse/templates/list/custom-topic-list-item.hbr
@@ -35,7 +35,7 @@
         {{~topic-featured-link topic}}
         {{~/if}}
         {{~#if showTopicPostBadges}}
-        {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+        {{~raw "topic-post-badges" unreadPosts=topic.unread_posts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
         {{~/if}}
       </div>
 


### PR DESCRIPTION
This PR:
1. Removes the modifyClass warning by adding a `pluginId` attribute when modifying a component class
2. Removes the `displayNewPosts` deprecation by updating the raw template override to match the changes made in core (https://github.com/discourse/discourse/pull/13471) and thus remove the deprecation.